### PR TITLE
공통 질문카드 컴포넌트 구현 및 Sass 구조화

### DIFF
--- a/app/_components/Badge.module.scss
+++ b/app/_components/Badge.module.scss
@@ -1,0 +1,24 @@
+.wrapper {
+  padding: 0.5rem;
+  border-radius: 1rem;
+  background-color: color('accent', 'yellow');
+  color: color('neutral', 'white');
+  font-size: small;
+  font-weight: 600;
+
+  &-01 {
+    background-color: color('highlight', '01');
+  }
+  &-02 {
+    background-color: color('highlight', '02');
+  }
+  &-03 {
+    background-color: color('highlight', '03');
+  }
+  &-04 {
+    background-color: color('highlight', '04');
+  }
+  &-05 {
+    background-color: color('neutral', 'grey');
+  }
+}

--- a/app/_components/Badge.module.scss
+++ b/app/_components/Badge.module.scss
@@ -5,6 +5,7 @@
   color: color('neutral', 'white');
   font-size: small;
   font-weight: 600;
+  align-content: center;
 
   &-01 {
     background-color: color('highlight', '01');

--- a/app/_components/Badge.module.scss
+++ b/app/_components/Badge.module.scss
@@ -1,9 +1,9 @@
 .wrapper {
-  padding: 0.5rem;
+  padding: 4px 7px;
   border-radius: 1rem;
   background-color: color('accent', 'yellow');
   color: color('neutral', 'white');
-  font-size: small;
+  font-size: 12px;
   font-weight: 600;
   align-content: center;
 

--- a/app/_components/Badge.tsx
+++ b/app/_components/Badge.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import styles from './Badge.module.scss';
 
 export default function Badge({
-  option: { title, shade },
+  option: { title, shade = '05' },
 }: {
   option: { title: string; shade?: '01' | '02' | '03' | '04' | '05' };
 }) {

--- a/app/_components/Badge.tsx
+++ b/app/_components/Badge.tsx
@@ -1,0 +1,11 @@
+import clsx from 'clsx';
+
+import styles from './Badge.module.scss';
+
+export default function Badge({
+  option: { title, shade },
+}: {
+  option: { title: string; shade?: '01' | '02' | '03' | '04' | '05' };
+}) {
+  return <div className={clsx(styles.wrapper, shade && styles[`wrapper-${shade}`])}>{title}</div>;
+}

--- a/app/_components/InterviewChat.module.scss
+++ b/app/_components/InterviewChat.module.scss
@@ -1,0 +1,6 @@
+.main {
+  width: 100%;
+  height: 100vh;
+  padding: 3rem;
+  // background-color: aliceblue;
+}

--- a/app/_components/InterviewChat.tsx
+++ b/app/_components/InterviewChat.tsx
@@ -1,4 +1,8 @@
 'use client';
+import QuestionCard from '@/app/_components/QuestionCard';
+
+import styles from './InterviewChat.module.scss';
+
 interface InterviewChatProps {
   devType: string;
   topics: string[];
@@ -6,10 +10,14 @@ interface InterviewChatProps {
 }
 export default function InterviewChat({ devType, topics, subTopics }: InterviewChatProps) {
   return (
-    <div>
+    <div className={styles.main}>
       <div>{devType}</div>
       <div>{topics.join(',')}</div>
       <div>{subTopics.join(',')}</div>
+      질문답변 페이지
+      <QuestionCard isSelected={false} level={'01'} />
+      <QuestionCard isSelected={false} level={'02'} />
+      <QuestionCard isSelected={false} level={'03'} />
     </div>
   );
 }

--- a/app/_components/QuestionCard.module.scss
+++ b/app/_components/QuestionCard.module.scss
@@ -1,0 +1,57 @@
+.question-card {
+  min-width: 31rem;
+
+  @include primary-box;
+
+  // 상단 제목 영역
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: left;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    font-weight: bold;
+  }
+
+  // 질문 영역
+  &__question {
+    width: 100%;
+    border-radius: 8px;
+    background-color: color('brand', 'main');
+
+    &-content {
+      border-radius: 10px 7px 7px 10px;
+      padding: 12px;
+      color: color('text', 'default');
+
+      margin-left: 8px;
+      width: calc(100% - 8px);
+
+      text-align: left;
+      background-color: color('neutral', 'pureWhite');
+    }
+  }
+
+  // 하단 답변 영역
+  &__answer {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: right;
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+
+  &__score {
+    font-weight: 500;
+    color: color('text', 'sub');
+  }
+
+  &__button--view {
+    @extend %square-button;
+  }
+  &__button--new {
+    @extend %square-button;
+    background-color: color('highlight', '01');
+  }
+}

--- a/app/_components/QuestionCard.tsx
+++ b/app/_components/QuestionCard.tsx
@@ -5,18 +5,31 @@ import clsx from 'clsx';
 import Badge from './Badge';
 import CardStyles from './QuestionCard.module.scss';
 
+type ShadeType = '01' | '02' | '03' | '04' | '05';
+
 interface QuestionCardProps {
   // question: string;
   isSelected?: boolean;
   onClick?: () => void;
+  level?: ShadeType;
 }
 
-export default function QuestionCard({ isSelected = false, onClick }: QuestionCardProps) {
+const IMPORTANCE_LEVEL: Record<ShadeType, { title: string; shade: ShadeType }> = {
+  '01': { title: '최우선 🚨', shade: '01' },
+  '02': { title: '필수 ⭐️⭐️⭐️', shade: '02' },
+  '03': { title: '중요 ⭐️⭐️', shade: '03' },
+  '04': { title: '기본 ⭐️', shade: '03' },
+  '05': { title: '심화', shade: '05' },
+};
+
+export default function QuestionCard({ isSelected = false, onClick, level = '05' }: QuestionCardProps) {
+  const { title, shade } = IMPORTANCE_LEVEL[level];
+
   return (
     <div className={wrapperClass(isSelected)} onClick={onClick} aria-label={'질문'}>
       <header className={CardStyles['question-card__header']}>
         <span className={CardStyles['question-card__topic']}>주제</span>
-        <Badge option={{ title: '중요도' }}></Badge>
+        <Badge option={{ title, shade }}></Badge>
       </header>
 
       <section className={CardStyles['question-card__question']}>

--- a/app/_components/QuestionCard.tsx
+++ b/app/_components/QuestionCard.tsx
@@ -1,0 +1,39 @@
+// 'use client';
+
+import clsx from 'clsx';
+
+import Badge from './Badge';
+import CardStyles from './QuestionCard.module.scss';
+
+interface QuestionCardProps {
+  // question: string;
+  isSelected?: boolean;
+  onClick?: () => void;
+}
+
+export default function QuestionCard({ isSelected = false, onClick }: QuestionCardProps) {
+  return (
+    <div className={wrapperClass(isSelected)} onClick={onClick} aria-label={'질문'}>
+      <header className={CardStyles['question-card__header']}>
+        <span className={CardStyles['question-card__topic']}>주제</span>
+        <Badge option={{ title: '중요도' }}></Badge>
+      </header>
+
+      <section className={CardStyles['question-card__question']}>
+        <p className={CardStyles['question-card__question-content']}>Q. React의 장점은 무엇인가요?</p>
+      </section>
+
+      <footer className={CardStyles['question-card__answer']}>
+        <span className={CardStyles['question-card__score']}>점수</span>
+        <button className={CardStyles['question-card__button--view']}>답변 보기</button>
+        <button className={CardStyles['question-card__button--new']}>다른 주제</button>
+      </footer>
+    </div>
+  );
+}
+
+function wrapperClass(selected: boolean) {
+  return clsx(CardStyles['question-card'], {
+    [CardStyles['question-card--selected']]: selected,
+  });
+}

--- a/app/_components/SelectButton.module.scss
+++ b/app/_components/SelectButton.module.scss
@@ -1,13 +1,13 @@
 .wrapper {
   border: none;
   width: 100%;
-  background-color: $default-white-color;
+  background-color: color('neutral', 'white');
   display: flex;
   flex-direction: column;
   justify-content: center;
   padding: 1.5rem 3rem;
   border-radius: 1rem;
-  box-shadow: 0 3px 8px $default-shadow-color;
+  box-shadow: 0 3px 8px color('shadow', 'default');
   cursor: pointer;
   margin-bottom: 1rem;
   transition: transform 0.2s ease;
@@ -17,28 +17,28 @@
   }
 
   &--selected {
-    box-shadow: 0 3px 8px $default-select-color;
-    border: 2px solid $default-select-color;
+    box-shadow: 0 3px 8px color('accent', 'select');
+    border: 2px solid color('accent', 'select');
   }
 
   &__title {
     font-size: 27px;
     font-weight: bold;
-    color: $sub-color;
+    color: color('brand', 'sub');
     display: flex;
     gap: 1rem;
   }
 
   &__description {
-    color: $sub-text-color;
+    color: color('text', 'sub');
     font-size: 1rem;
     font-weight: 500;
     margin: 1rem 0 2rem 0;
   }
 
   &__topics span {
-    background-color: $default-yellow-color;
-    color: $default-white-color;
+    background-color: color('accent', 'yellow');
+    color: color('neutral', 'white');
     margin: 0 0.5rem 2rem 0;
     padding: 3px 16px;
     border-radius: 2rem;

--- a/app/_components/SelectButton.module.scss
+++ b/app/_components/SelectButton.module.scss
@@ -1,25 +1,5 @@
 .wrapper {
-  border: none;
-  width: 100%;
-  background-color: color('neutral', 'white');
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  padding: 1.5rem 3rem;
-  border-radius: 1rem;
-  box-shadow: 0 3px 8px color('shadow', 'default');
-  cursor: pointer;
-  margin-bottom: 1rem;
-  transition: transform 0.2s ease;
-
-  &:hover:not(&--selected) {
-    transform: translateY(-0.25rem);
-  }
-
-  &--selected {
-    box-shadow: 0 3px 8px color('accent', 'select');
-    border: 2px solid color('accent', 'select');
-  }
+  @include primary-box;
 
   &__title {
     font-size: 27px;

--- a/app/_components/TopicSelector.module.scss
+++ b/app/_components/TopicSelector.module.scss
@@ -1,5 +1,5 @@
 .sub_title {
-  color: $sub-text-color;
+  color: color('text', 'sub');
   font-size: 1rem;
   margin-bottom: 1rem;
 

--- a/app/_styles/_abstracts/_buttons.scss
+++ b/app/_styles/_abstracts/_buttons.scss
@@ -22,3 +22,17 @@
     transform: translateY(-0.25rem);
   }
 }
+
+%square-button {
+  padding: 5px 10px;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  background-color: color('brand', 'sub');
+  color: color('neutral', 'white');
+
+  &:hover {
+    filter: brightness(1.2);
+  }
+}

--- a/app/_styles/_abstracts/_buttons.scss
+++ b/app/_styles/_abstracts/_buttons.scss
@@ -9,13 +9,13 @@
   align-items: center;
   width: 7rem;
   height: 2.5rem;
-  color: $default-white-color;
+  color: color('neutral', 'white');
   font-size: large;
   font-weight: bold;
   cursor: pointer;
-  background-color: $default-select-color;
+  background-color: color('accent', 'select');
   border-radius: 2rem;
-  box-shadow: 0 1rem 1.3rem $button-shadow-color;
+  box-shadow: 0 1rem 1.3rem color('shadow', 'button');
   transition: transform 0.2s ease;
 
   &:hover {

--- a/app/_styles/_abstracts/_mixins.scss
+++ b/app/_styles/_abstracts/_mixins.scss
@@ -1,0 +1,25 @@
+@use 'variables' as *;
+
+@mixin primary-box {
+  border: none;
+  width: 100%;
+  background-color: color('neutral', 'white');
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.5rem 3rem;
+  border-radius: 1rem;
+  box-shadow: 0 3px 8px color('shadow', 'default');
+  cursor: pointer;
+  margin-bottom: 1rem;
+  transition: transform 0.2s ease;
+
+  &:hover:not(&--selected) {
+    transform: translateY(-0.25rem);
+  }
+
+  &--selected {
+    box-shadow: 0 3px 8px color('accent', 'select');
+    border: 2px solid color('accent', 'select');
+  }
+}

--- a/app/_styles/_abstracts/_variables.scss
+++ b/app/_styles/_abstracts/_variables.scss
@@ -1,22 +1,46 @@
-// color
-$default-bg-color: #fefbf3;
-$sub-bg-color: #eff6ff;
+@use 'sass:map';
 
-$main-color: #f0c387;
-$sub-color: #2b4c7e;
-$highlight-color: #ff6b35;
+$colors: (
+  'background': (
+    'default': #fefbf3,
+    'sub': #eff6ff,
+  ),
+  'brand': (
+    'main': #f0c387,
+    'sub': #2b4c7e,
+  ),
+  'highlight': (
+    '01': #ff6b35,
+    '02': #ffb535,
+    '03': #ffdf53,
+    '04': #7dd45b,
+  ),
+  'text': (
+    'default': #1f364d,
+    'sub': #5b6c7e,
+  ),
+  'neutral': (
+    'grey': #d9d9d9,
+    'black': #14212b,
+    'white': #fffcfb,
+  ),
+  'accent': (
+    'yellow': #fecf75,
+    'select': #74a6f2,
+  ),
+  'shadow': (
+    'default': rgba(95, 84, 62, 0.2),
+    'button': rgba(62, 73, 95, 0.2),
+  ),
+);
 
-$default-text-color: #1f364d;
-$sub-text-color: #5b6c7e;
+@function color($category, $shade) {
+  @return map.get(map.get($colors, $category), $shade);
+}
 
-$default-black-color: #14212b;
-$default-white-color: #fffcfb;
-$default-yellow-color: #fecf75;
-$default-select-color: #74a6f2;
-
-$default-shadow-color: rgba(95, 84, 62, 0.2);
-$button-shadow-color: rgba(62, 73, 95, 0.2);
-
-//test color
-$test-color1: aliceblue;
-$test-color2: red;
+// NOTE
+// 사용 예시
+// .element {
+//   background-color: color('background', 'default');
+//   color: color('text', 'primary');
+// }

--- a/app/_styles/_abstracts/_variables.scss
+++ b/app/_styles/_abstracts/_variables.scss
@@ -23,6 +23,7 @@ $colors: (
     'grey': #d9d9d9,
     'black': #14212b,
     'white': #fffcfb,
+    'pureWhite': #ffffff,
   ),
   'accent': (
     'yellow': #fecf75,

--- a/app/_styles/globals.scss
+++ b/app/_styles/globals.scss
@@ -15,8 +15,8 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color: $default-text-color;
-  background: $default-bg-color;
+  color: color('text', 'default');
+  background: color('background', 'default');
 }
 
 * {
@@ -46,5 +46,5 @@ li {
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: $default-bg-color;
+  background-color: color('background', 'default');
 }

--- a/app/interview/chat/page.module.scss
+++ b/app/interview/chat/page.module.scss
@@ -1,0 +1,4 @@
+.main {
+  width: 100%;
+  height: 100%;
+}

--- a/app/interview/chat/page.tsx
+++ b/app/interview/chat/page.tsx
@@ -2,6 +2,7 @@ import InterviewChat from '@/app/_components/InterviewChat';
 import { isDeveloperType, isValidSubTopicParam, isValidTopicParam } from '@/app/_helpers/typeGuards';
 import SelectLayout from '@/app/interview/select/_components/SelectLayout';
 
+import styles from './page.module.scss';
 interface ChatPageType {
   searchParams: Promise<{ devType: string; topics: string; subTopics: string }>;
 }
@@ -32,7 +33,7 @@ export default async function ChatPage({ searchParams }: ChatPageType) {
   }
 
   return (
-    <div>
+    <div className={styles.main}>
       <InterviewChat devType={devType} topics={topics.split(',')} subTopics={subTopics.split(',')} />
     </div>
   );

--- a/app/interview/select/[devType]/devTypePage.module.scss
+++ b/app/interview/select/[devType]/devTypePage.module.scss
@@ -12,13 +12,13 @@
   &__title {
     font-size: 2rem;
     font-weight: bold;
-    color: $default-text-color;
+    color: color('text', 'default');
     margin-bottom: 1.5rem;
   }
 
   &__sub-title {
     font-size: 1.2rem;
-    color: $default-text-color;
+    color: color('text', 'default');
     // margin-bottom: 2rem;
   }
 

--- a/app/interview/select/_components/SelectLayout.module.scss
+++ b/app/interview/select/_components/SelectLayout.module.scss
@@ -16,12 +16,12 @@
   &__title {
     font-size: 2rem;
     font-weight: bold;
-    color: $default-text-color;
+    color: color('text', 'default');
   }
 
   &__sub-title {
     font-size: 1.2rem;
-    color: $default-text-color;
+    color: color('text', 'default');
   }
 
   &__selectBox {

--- a/app/page.module.scss
+++ b/app/page.module.scss
@@ -1,7 +1,7 @@
 .main {
   width: 100%;
   height: 100%;
-  background: linear-gradient(-180deg, $default-bg-color, $sub-bg-color);
+  background: linear-gradient(-180deg, color('background', 'defualt'), color('background', 'sub'));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -20,20 +20,20 @@
   &__title {
     font-size: 3rem;
     font-weight: bold;
-    color: $default-text-color;
+    color: color('text', 'defualt');
     text-align: center;
     margin-bottom: 1rem;
   }
 
   &__sub-title {
     font-size: 1.2rem;
-    color: $default-text-color;
+    color: color('text', 'default');
     text-align: center;
     margin-bottom: 2rem;
   }
 
   &__description {
-    color: $sub-text-color;
+    color: color('text', 'sub');
     font-size: 1.2rem;
     margin-bottom: 2rem;
   }
@@ -52,7 +52,7 @@
     left: 50%;
     transform: translate(-50%, -50%);
     border-radius: 50%;
-    box-shadow: 0 2rem 1rem $default-shadow-color;
+    box-shadow: 0 2rem 1rem color('shadow', 'default');
     z-index: 1;
   }
 

--- a/app/page.module.scss
+++ b/app/page.module.scss
@@ -1,7 +1,12 @@
+$gradient-start: color('background', 'default');
+$gradient-end: color('background', 'sub');
+
 .main {
   width: 100%;
   height: 100%;
-  background: linear-gradient(-180deg, color('background', 'defualt'), color('background', 'sub'));
+  $bg-default: color('background', 'default');
+  $bg-sub: color('background', 'sub');
+  background: linear-gradient(-180deg, $gradient-start, $gradient-end);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,8 +6,9 @@ const nextConfig: NextConfig = {
   /* config options here */
   sassOptions: {
     includePaths: [path.join(__dirname, 'app', '_styles')],
-    prependData: `@use "./_abstracts/variables" as *; 
-    @use "./_abstracts/buttons" as *;`,
+    prependData: `@use "./_abstracts/_variables" as *; 
+    @use "./_abstracts/_buttons" as *;
+    @use "./_abstracts/_mixins" as *;`,
   },
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #20

## 📝작업 내용
>Sass 변수를 맵으로 구조화
Mixin 기반 공통 스타일 구현
공통 컴포넌트 개발 (뱃지, 질문카드)

### 1. Sass 변수를 맵으로 구조화
- 기존 단일 변수들을 맵(Map) 구조로 리팩토링
- 변수 증가에 따른 유지보수성 및 가독성 개선
- 색상, 크기 등의 변수들을 카테고리별로 구조화

### 2. Mixin 기반 공통 스타일 구현
- `@extend` 사용 시 발생하던 컴파일 오류
- `%primary-box` → `@mixin primary-box` 방식으로 변경하여 해결
- `@include` 사용으로 안정성 확보

### 3. 공통 컴포넌트 개발
#### Badge 컴포넌트
- 중요도 표시 및 키워드 하이라이팅을 위한 범용 뱃지 구현
- 사이드바 핵심 키워드 표시 기능 고려
- 재사용성을 고려한 컴포넌트 설계

#### QuestionCard 컴포넌트
- 중요도 레벨에 따른 뱃지 텍스트 및 색상 상수화
- Badge 컴포넌트 통합
- 일관된 디자인 시스템 적용

### 스크린샷 (선택)
![question-card](https://github.com/user-attachments/assets/9b997eb2-63d1-4a1c-913e-3b310cd79a6d)

## 알게된 내용

### `@extend` vs `@mixin`

### 1. `@extend`와 `@mixin`의 주요 차이점
- CSS Modules나 Styled Components와 같은 모듈 기반 CSS에서는 `@extend`가 제대로 작동하지 않음
- `@extend`는 컴파일 시점에 동일한 스타일 블록 내에서만 작동
- `%placeholder` 선택자 사용 시 주의사항:
  - placeholder가 정의된 파일이 import되지 않거나
  - 컴파일 순서에 문제가 있으면 에러 발생
```
// 에러가 발생할 수 있는 경우
%primary-box {
  background: blue;
  color: white;
}

// 다른 모듈/파일에서
.button {
  @extend %primary-box; // 컴파일 에러 발생 가능
}
```
### 2. `@mixin`의 장점
- 모듈 간 독립성 보장 (각 컴포넌트가 자신의 스타일을 완전히 포함)
- 선택자 간 연관성이 없지만 코드가 겹치는 경우 사용하여 중복 제거

### 3. 사용 기준
- `@extend`: 명백히 연관성이 있는 규칙들 사이에 특성을 공유할 때 사용
- 컴파일 결과물의 반복은 문제가 되지 않음. 소스 코드의 반복이 문제
- 한 주제로 묶여 있을 때만 @extend를 사용하자
- 연관성 없는 요소들을 강제로 묶지 말 것 (코드가 이상하게 묶이고 소스 순서가 이상해짐)

### 4. `@mixin`의 활용
- 연관성은 없지만 코드가 겹치는 선택자들이라면 mixin으로 소스코드의 중복을 없애기 위해 사용하자
- 프로젝트의 단일 진리의 원천(single source of truth) 유지를 위한 도구로 활용
- 모듈 간 독립성이 보장됩니다 (각 컴포넌트가 자신의 스타일을 완전히 포함)

### 참고 
https://medium.com/@linker21/scss-placeholders-vs-mixins-fe79b9dbb6d5
https://mytory.net/archives/13182
