### PR TITLE
헬퍼 펑션 단위테스트 및 질문 카드 컴포넌트 테스트

### DIFF
--- a/app/_components/QuestionCard.test.tsx
+++ b/app/_components/QuestionCard.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import '@testing-library/jest-dom';
+import QuestionCard, { IMPORTANCE_LEVEL } from './QuestionCard';
+
+describe('QuestionCard', () => {
+  it('중요도 레벨에 따라 올바른 Badge가 렌더링된다', () => {
+    render(<QuestionCard level="01" />);
+    expect(screen.getByText(IMPORTANCE_LEVEL['01'].title)).toBeInTheDocument();
+
+    cleanup();
+    render(<QuestionCard level="02" />);
+    expect(screen.getByText(IMPORTANCE_LEVEL['02'].title)).toBeInTheDocument();
+
+    cleanup();
+    render(<QuestionCard level="03" />);
+    expect(screen.getByText(IMPORTANCE_LEVEL['03'].title)).toBeInTheDocument();
+
+    cleanup();
+    render(<QuestionCard level="04" />);
+    expect(screen.getByText(IMPORTANCE_LEVEL['04'].title)).toBeInTheDocument();
+
+    cleanup();
+    render(<QuestionCard level="05" />);
+    expect(screen.getByText(IMPORTANCE_LEVEL['05'].title)).toBeInTheDocument();
+  });
+});

--- a/app/_components/QuestionCard.tsx
+++ b/app/_components/QuestionCard.tsx
@@ -14,7 +14,7 @@ interface QuestionCardProps {
   level?: ShadeType;
 }
 
-const IMPORTANCE_LEVEL: Record<ShadeType, { title: string; shade: ShadeType }> = {
+export const IMPORTANCE_LEVEL: Record<ShadeType, { title: string; shade: ShadeType }> = {
   '01': { title: '최우선 🚨', shade: '01' },
   '02': { title: '필수 ⭐️⭐️⭐️', shade: '02' },
   '03': { title: '중요 ⭐️⭐️', shade: '03' },

--- a/app/_components/TopicSelector.test.tsx
+++ b/app/_components/TopicSelector.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DeveloperType } from '@/app/_types/interview';
 import '@testing-library/jest-dom';
-import { DeveloperType } from '../_types/interview';
+
 import buttonStyles from './SelectButton.module.scss';
 import TopicSelector from './TopicSelector';
 
@@ -125,53 +126,6 @@ describe('TopicSelector', () => {
 
       // 카운터 업데이트 확인
       expect(screen.getByText(`${defaultProps.topics.length - 1}/${defaultProps.topics.length}`)).toBeInTheDocument();
-    });
-  });
-
-  describe('-라우팅 관련', () => {
-    it('topic 타입에서 전체 선택 후 라우팅', () => {
-      render(<TopicSelector {...defaultProps} variant="topic" />);
-
-      // 전체 선택
-      const allButton = screen.getByRole('button', { name: allTopicsButtonText });
-      fireEvent.click(allButton);
-
-      // 다음 버튼 클릭
-      const nextButton = screen.getByRole('button', { name: nextButtonText });
-      fireEvent.click(nextButton);
-
-      // 라우팅 확인
-      expect(mockPush).toHaveBeenCalledWith(ROUTES.TOPIC.build(defaultProps.devType, 'all'));
-    });
-
-    it('topic 타입에서 개별 선택 후 라우팅', () => {
-      render(<TopicSelector {...defaultProps} variant="topic" />);
-
-      // 개별 선택
-      const topicButton = screen.getByRole('button', { name: firstTopicName });
-      fireEvent.click(topicButton);
-
-      // 다음 버튼 클릭
-      const nextButton = screen.getByRole('button', { name: nextButtonText });
-      fireEvent.click(nextButton);
-
-      // 라우팅 확인
-      expect(mockPush).toHaveBeenCalledWith(ROUTES.TOPIC.build(defaultProps.devType, firstTopicName));
-    });
-
-    it('subTopic 타입 라우팅', () => {
-      render(<TopicSelector {...defaultProps} variant="subTopic" />);
-
-      // 주제 선택
-      const topicButton = screen.getByRole('button', { name: firstTopicName });
-      fireEvent.click(topicButton);
-
-      // 다음 버튼 클릭
-      const nextButton = screen.getByRole('button', { name: nextButtonText });
-      fireEvent.click(nextButton);
-
-      // 라우팅 확인
-      expect(mockPush).toHaveBeenCalledWith(ROUTES.SUBTOPIC);
     });
   });
 });

--- a/app/_components/TopicSelector.tsx
+++ b/app/_components/TopicSelector.tsx
@@ -2,15 +2,15 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 
-import { getTopicParam, getVaildTopics } from '@/app/_helpers/interviewHelpers';
+import { handleNavigation } from '@/app/_helpers/interviewHelpers';
 import useTopicSelector from '@/app/_hooks/useTopicSelector';
-import { DeveloperType } from '@/app/_types/interview';
+import { DeveloperType, SelectorVariant } from '@/app/_types/interview';
 
 import SelectButton from './SelectButton';
 import styles from './TopicSelector.module.scss';
 
 export interface TopicSelectorProps {
-  variant?: 'topic' | 'subTopic';
+  variant?: SelectorVariant;
   devType: DeveloperType;
   topics: string[];
 }
@@ -23,40 +23,9 @@ export default function TopicSelector({ variant = 'topic', devType, topics }: To
       topics,
     });
 
-  const getParamsForChat = () => {
-    const subTopicParam = getTopicParam(isAllSelected, selectedTopics);
-    const topicsParam =
-      searchParams.get('topics') === 'all' ? getVaildTopics(devType).join(',') : searchParams.get('topics');
-    const params = new URLSearchParams({
-      devType,
-      topics: topicsParam || '',
-      subTopics: subTopicParam,
-    });
-
-    return params;
-  };
-
-  const getParamsForSubTopic = () => {
-    const topicsParam = getTopicParam(isAllSelected, selectedTopics);
-    const params = new URLSearchParams({
-      topics: topicsParam,
-    });
-
-    return params;
-  };
-
-  const handleNavigation = () => {
-    if (!selectedTopics.length) return;
-
-    switch (variant) {
-      case 'topic':
-        router.push(`/interview/select/${devType}/prepare?${getParamsForSubTopic()}`);
-        break;
-
-      case 'subTopic':
-        router.push(`/interview/chat?${getParamsForChat()}`);
-        break;
-    }
+  const handleNextClick = () => {
+    const nextRoute = handleNavigation(variant, devType, selectedTopics, isAllSelected, searchParams);
+    if (nextRoute) router.push(nextRoute);
   };
 
   return (
@@ -87,7 +56,7 @@ export default function TopicSelector({ variant = 'topic', devType, topics }: To
         ))}
       </div>
 
-      <button className={styles['next-button']} onClick={handleNavigation} disabled={notSelected}>
+      <button className={styles['next-button']} onClick={() => handleNextClick} disabled={notSelected}>
         다음
       </button>
     </>

--- a/app/_helpers/interviewHelpers.test.ts
+++ b/app/_helpers/interviewHelpers.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTopicParam, handleNavigation } from './interviewHelpers';
+
+describe('interviewHelpers', () => {
+  const TEST_CASES = {
+    topic: {
+      individual: {
+        input: {
+          variant: 'topic' as const,
+          devType: 'FrontEnd' as const,
+          selectedTopics: ['React'],
+          isAllSelected: false,
+          searchParams: new URLSearchParams(),
+        },
+        expected: '/interview/select/FrontEnd/prepare?topics=React',
+      },
+      all: {
+        input: {
+          variant: 'topic' as const,
+          devType: 'FrontEnd' as const,
+          selectedTopics: ['React', 'JavaScript'],
+          isAllSelected: true,
+          searchParams: new URLSearchParams(),
+        },
+        expected: '/interview/select/FrontEnd/prepare?topics=all',
+      },
+    },
+  };
+
+  describe('handleNavigation (핵심)', () => {
+    it('topic 타입 - 개별 선택', () => {
+      const { input, expected } = TEST_CASES.topic.individual;
+      const result = handleNavigation(
+        input.variant,
+        input.devType,
+        input.selectedTopics,
+        input.isAllSelected,
+        input.searchParams
+      );
+      expect(result).toBe(expected);
+    });
+
+    it('topic 타입 - 전체 선택', () => {
+      const { input, expected } = TEST_CASES.topic.all;
+      const result = handleNavigation(
+        input.variant,
+        input.devType,
+        input.selectedTopics,
+        input.isAllSelected,
+        input.searchParams
+      );
+      expect(result).toBe(expected);
+    });
+  });
+
+  describe('getTopicParam (중요)', () => {
+    it('전체 선택시 "all" 반환', () => {
+      expect(getTopicParam(true, ['React'])).toBe('all');
+    });
+
+    it('개별 선택시 콤마로 구분된 문자열 반환', () => {
+      expect(getTopicParam(false, ['React', 'JavaScript'])).toBe('React,JavaScript');
+    });
+  });
+});

--- a/app/_helpers/interviewHelpers.test.ts
+++ b/app/_helpers/interviewHelpers.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { getTopicParam, handleNavigation } from './interviewHelpers';
+import {
+  getSelectedTopics,
+  getTopicParam,
+  getVaildSubTopics,
+  getVaildTopics,
+  handleNavigation,
+} from './interviewHelpers';
+
+// DEVELOPER_OPTIONS Mock
+vi.mock('@/app/interview/_constants/developers', () => ({
+  DEVELOPER_OPTIONS: {
+    FrontEnd: {
+      topics: {
+        JavaScript: ['스코프', '클로저'],
+        React: ['훅스', '상태관리'],
+        TypeScript: ['타입추론', '제네릭'],
+      },
+    },
+  },
+}));
 
 describe('interviewHelpers', () => {
   const TEST_CASES = [
@@ -26,6 +45,19 @@ describe('interviewHelpers', () => {
       },
       expected: '/interview/select/FrontEnd/prepare?topics=all',
     },
+    {
+      name: 'subTopic 타입 - URL에 모든 필수 파라미터 포함',
+      input: {
+        variant: 'subTopic' as const,
+        devType: 'FrontEnd' as const,
+        selectedTopics: ['JavaScript'],
+        isAllSelected: false,
+        searchParams: new URLSearchParams({
+          topics: 'JavaScript',
+        }),
+      },
+      expected: '/interview/chat?devType=FrontEnd&topics=JavaScript&subTopics=JavaScript',
+    },
   ];
 
   describe('handleNavigation (핵심)', () => {
@@ -50,6 +82,46 @@ describe('interviewHelpers', () => {
 
     it('개별 선택시 콤마로 구분된 문자열 반환', () => {
       expect(getTopicParam(false, ['React', 'JavaScript'])).toBe('React,JavaScript');
+    });
+
+    it('선택된 토픽이 없을 때 빈 문자열 반환', () => {
+      expect(getTopicParam(false, [])).toBe('');
+    });
+  });
+
+  describe('getVaildTopics', () => {
+    it('devType에 해당하는 모든 토픽을 반환한다', () => {
+      const result = getVaildTopics('FrontEnd');
+      expect(result).toEqual(['JavaScript', 'React', 'TypeScript']);
+    });
+  });
+
+  describe('getVaildSubTopics', () => {
+    it('특정 토픽의 모든 서브토픽을 반환한다', () => {
+      const result = getVaildSubTopics('FrontEnd', 'JavaScript');
+      expect(result).toEqual(['스코프', '클로저']);
+    });
+
+    it('존재하지 않는 토픽의 경우 빈 배열을 반환한다', () => {
+      const result = getVaildSubTopics('FrontEnd', 'nonexistent');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getSelectedTopics', () => {
+    it('param이 "all"인 경우 모든 유효한 토픽을 반환한다', () => {
+      const result = getSelectedTopics('FrontEnd', 'all');
+      expect(result).toEqual(['JavaScript', 'React', 'TypeScript']);
+    });
+
+    it('콤마로 구분된 토픽 문자열을 배열로 반환한다', () => {
+      const result = getSelectedTopics('FrontEnd', 'JavaScript,React');
+      expect(result).toEqual(['JavaScript', 'React']);
+    });
+
+    it('빈 문자열인 경우 빈 배열을 반환한다', () => {
+      const result = getSelectedTopics('FrontEnd', '');
+      expect(result).toEqual(['']);
     });
   });
 });

--- a/app/_helpers/interviewHelpers.test.ts
+++ b/app/_helpers/interviewHelpers.test.ts
@@ -3,54 +3,43 @@ import { describe, expect, it } from 'vitest';
 import { getTopicParam, handleNavigation } from './interviewHelpers';
 
 describe('interviewHelpers', () => {
-  const TEST_CASES = {
-    topic: {
-      individual: {
-        input: {
-          variant: 'topic' as const,
-          devType: 'FrontEnd' as const,
-          selectedTopics: ['React'],
-          isAllSelected: false,
-          searchParams: new URLSearchParams(),
-        },
-        expected: '/interview/select/FrontEnd/prepare?topics=React',
+  const TEST_CASES = [
+    {
+      name: 'topic 타입 - 개별 선택',
+      input: {
+        variant: 'topic' as const,
+        devType: 'FrontEnd' as const,
+        selectedTopics: ['React'],
+        isAllSelected: false,
+        searchParams: new URLSearchParams(),
       },
-      all: {
-        input: {
-          variant: 'topic' as const,
-          devType: 'FrontEnd' as const,
-          selectedTopics: ['React', 'JavaScript'],
-          isAllSelected: true,
-          searchParams: new URLSearchParams(),
-        },
-        expected: '/interview/select/FrontEnd/prepare?topics=all',
-      },
+      expected: '/interview/select/FrontEnd/prepare?topics=React',
     },
-  };
+    {
+      name: 'topic 타입 - 전체 선택',
+      input: {
+        variant: 'topic' as const,
+        devType: 'FrontEnd' as const,
+        selectedTopics: ['React', 'JavaScript'],
+        isAllSelected: true,
+        searchParams: new URLSearchParams(),
+      },
+      expected: '/interview/select/FrontEnd/prepare?topics=all',
+    },
+  ];
 
   describe('handleNavigation (핵심)', () => {
-    it('topic 타입 - 개별 선택', () => {
-      const { input, expected } = TEST_CASES.topic.individual;
-      const result = handleNavigation(
-        input.variant,
-        input.devType,
-        input.selectedTopics,
-        input.isAllSelected,
-        input.searchParams
-      );
-      expect(result).toBe(expected);
-    });
-
-    it('topic 타입 - 전체 선택', () => {
-      const { input, expected } = TEST_CASES.topic.all;
-      const result = handleNavigation(
-        input.variant,
-        input.devType,
-        input.selectedTopics,
-        input.isAllSelected,
-        input.searchParams
-      );
-      expect(result).toBe(expected);
+    TEST_CASES.forEach(({ name, input, expected }) => {
+      it(name, () => {
+        const result = handleNavigation(
+          input.variant,
+          input.devType,
+          input.selectedTopics,
+          input.isAllSelected,
+          input.searchParams
+        );
+        expect(result).toBe(expected);
+      });
     });
   });
 

--- a/app/_helpers/interviewHelpers.ts
+++ b/app/_helpers/interviewHelpers.ts
@@ -1,4 +1,4 @@
-import { DeveloperType } from '@/app/_types/interview';
+import { DeveloperType, SelectorVariant } from '@/app/_types/interview';
 import { DEVELOPER_OPTIONS } from '@/app/interview/_constants/developers';
 
 export const getTopicParam = (isAllSelected: boolean, selectedTopics: string[]): string =>
@@ -15,4 +15,49 @@ export const getSelectedTopics = (devType: DeveloperType, param: string) => {
   if (param === 'all') return validTopics;
 
   return param.split(',');
+};
+
+export const getParamsForChat = (
+  devType: DeveloperType,
+  isAllSelected: boolean,
+  selectedTopics: string[],
+  searchParams: URLSearchParams
+) => {
+  const subTopicParam = getTopicParam(isAllSelected, selectedTopics);
+  const topicsParam =
+    searchParams.get('topics') === 'all' ? getVaildTopics(devType).join(',') : searchParams.get('topics');
+  const params = new URLSearchParams({
+    devType,
+    topics: topicsParam || '',
+    subTopics: subTopicParam,
+  });
+
+  return params;
+};
+
+const getParamsForSubTopic = (isAllSelected: boolean, selectedTopics: string[]) => {
+  const topicsParam = getTopicParam(isAllSelected, selectedTopics);
+  const params = new URLSearchParams({
+    topics: topicsParam,
+  });
+
+  return params;
+};
+
+export const handleNavigation = (
+  variant: SelectorVariant,
+  devType: DeveloperType,
+  selectedTopics: string[],
+  isAllSelected: boolean,
+  searchParams: URLSearchParams
+) => {
+  if (!selectedTopics.length) return;
+
+  switch (variant) {
+    case 'topic':
+      return `/interview/select/${devType}/prepare?${getParamsForSubTopic(isAllSelected, selectedTopics)}`;
+
+    case 'subTopic':
+      return `/interview/chat?${getParamsForChat(devType, isAllSelected, selectedTopics, searchParams)}`;
+  }
 };

--- a/app/_types/interview.ts
+++ b/app/_types/interview.ts
@@ -13,3 +13,5 @@ export type OptionDetails = {
 export type DeveloperOptionType = {
   [K in DeveloperType]: OptionDetails;
 };
+
+export type SelectorVariant = 'topic' | 'subTopic';


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closes #26 

## 📝작업 내용

> interviewHelpers, QuestionCard 단위/컴포넌트 테스트
> 라우팅 관련 로직을 헬퍼로 분리하여 테스트
> 중요도 레벨에 따라 올바른 Badge 렌더링 테스트

URL 관련 로직은 별도의 유틸리티 테스트로 관심사 분리하여 테스트 진행하였습니다.

- topic/ subTopic 선택에 따른 정확한 URL을 반환하는지 테스트
- 특정 topic/ subTopic 에 해당하는 토픽을 반환하는지 테스트
- 'all'일 경우 전체를 반환하는지 테스트

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/e2bd59a4-6f20-42b6-bbd5-ffe9de1a411a)
